### PR TITLE
release: prepare v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## v0.1.0 (2026-03-30)
+
+### Added
+- Initial collection pipeline (collect_all.py)
+- Full processing pipeline (run_pipeline.py) 
+- Catalog export (export_catalog.py)
+- 13 source configurations across 7 categories
+- CI workflow with PostgreSQL
+- Test infrastructure

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "AI ecosystem research and collection store powered by DKB"
 requires-python = ">=3.12"
 license = {text = "MIT"}
 dependencies = [
-    "dkb-runtime",
+    "dkb-runtime @ git+https://github.com/songblaq/dkb-runtime.git@master",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Closes #8

## Summary
- Pinned dkb-runtime dependency
- Added CHANGELOG.md
- Version set to 0.1.0

## Test Plan
- [ ] `pip install -e '.[dev]'` succeeds
- [ ] Pipeline scripts importable

Made with [Cursor](https://cursor.com)