### PR TITLE
feat(ci): repository_dispatch + README CI badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  repository_dispatch:
+    types: [dkb-upstream-trigger]
 
 jobs:
   lint:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![CI](https://github.com/songblaq/ai-store-dkb/actions/workflows/ci.yml/badge.svg)
+
 # ai-store-dkb
 
 AI 생태계 전체를 리서치·수집하는 **DKB 스토어 인스턴스**.


### PR DESCRIPTION
Part of songblaq/directive-knowledge-base#10.

- Run CI on `repository_dispatch` type `dkb-upstream-trigger`.
- README CI badge.

Made with [Cursor](https://cursor.com)