### PR TITLE
E2E validation (issues #10–#13): 34-dimension file pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
           python-version: '3.12'
       - run: pip install ruff
       - run: ruff check scripts tests
+      - run: ruff format --check scripts tests
 
   test:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ venv/
 # Storage (local data)
 storage/
 
+# E2E collected payloads (regenerate with scripts/validate_e2e.py)
+data/validation/e2e_collected/
+
 # OS
 .DS_Store
 Thumbs.db

--- a/config/dimension_model_v0_1.json
+++ b/config/dimension_model_v0_1.json
@@ -1,0 +1,132 @@
+{
+  "model_key": "dg-v0-1",
+  "version": "0.1.0",
+  "description": "Directive Graph default dimension model for DKB v0.1",
+  "score_range": {
+    "min": 0.0,
+    "max": 1.0
+  },
+  "confidence_range": {
+    "min": 0.0,
+    "max": 1.0
+  },
+  "groups": [
+    {
+      "name": "form",
+      "dimensions": [
+        "skillness",
+        "agentness",
+        "workflowness",
+        "commandness",
+        "pluginness"
+      ]
+    },
+    {
+      "name": "function",
+      "dimensions": [
+        "planning",
+        "review",
+        "coding",
+        "research",
+        "ops",
+        "writing",
+        "content",
+        "orchestration"
+      ]
+    },
+    {
+      "name": "execution",
+      "dimensions": [
+        "atomicity",
+        "autonomy",
+        "multi_stepness",
+        "tool_dependence",
+        "composability",
+        "reusability"
+      ]
+    },
+    {
+      "name": "governance",
+      "dimensions": [
+        "officialness",
+        "legal_clarity",
+        "maintenance_health",
+        "install_verifiability",
+        "trustworthiness"
+      ]
+    },
+    {
+      "name": "adoption",
+      "dimensions": [
+        "star_signal",
+        "fork_signal",
+        "mention_signal",
+        "install_signal",
+        "freshness"
+      ]
+    },
+    {
+      "name": "clarity",
+      "dimensions": [
+        "naming_clarity",
+        "description_clarity",
+        "io_clarity",
+        "example_coverage",
+        "overlap_ambiguity_inverse"
+      ]
+    }
+  ],
+  "role_views": {
+    "skill_score": {
+      "from_groups": [
+        "form",
+        "function",
+        "execution",
+        "clarity"
+      ],
+      "notes": "높은 skillness, reusability, composability, description clarity를 선호"
+    },
+    "agent_score": {
+      "from_groups": [
+        "form",
+        "function",
+        "execution",
+        "governance"
+      ],
+      "notes": "높은 agentness, autonomy, orchestration 성향을 선호"
+    },
+    "workflow_score": {
+      "from_groups": [
+        "form",
+        "function",
+        "execution",
+        "clarity"
+      ],
+      "notes": "높은 workflowness, multi_stepness, io clarity를 선호"
+    },
+    "command_score": {
+      "from_groups": [
+        "form",
+        "execution",
+        "clarity"
+      ],
+      "notes": "높은 commandness, atomicity, naming clarity를 선호"
+    },
+    "plugin_score": {
+      "from_groups": [
+        "form",
+        "execution",
+        "governance"
+      ],
+      "notes": "높은 pluginness, tool dependence, install verifiability를 선호"
+    }
+  },
+  "explainability": {
+    "required": true,
+    "fields": [
+      "explanation",
+      "features",
+      "confidence"
+    ]
+  }
+}

--- a/config/e2e_validation_sources.json
+++ b/config/e2e_validation_sources.json
@@ -1,0 +1,27 @@
+{
+  "version": "0.2.0",
+  "description": "Minimal sources for scripts/validate_e2e.py (issues #10–#12). Issue #10 uses anthropics/skills; github.com/anthropic/claude-code-skills is not a public repository.",
+  "categories": {
+    "agent-skills-official": [
+      {
+        "origin_uri": "https://github.com/anthropics/skills",
+        "provenance_hint": "official",
+        "label": "Anthropic public skills (E2E #10)"
+      }
+    ],
+    "claude-code": [
+      {
+        "origin_uri": "https://github.com/hesreallyhim/awesome-claude-code",
+        "provenance_hint": "community",
+        "label": "Awesome Claude Code (E2E #11)"
+      }
+    ],
+    "mcp": [
+      {
+        "origin_uri": "https://github.com/modelcontextprotocol/servers",
+        "provenance_hint": "official",
+        "label": "MCP official servers (E2E #12)"
+      }
+    ]
+  }
+}

--- a/data/validation/processed/directives.json
+++ b/data/validation/processed/directives.json
@@ -1,0 +1,262 @@
+{
+  "version": "0.2.0",
+  "directive_count": 3,
+  "dimension_model_path": "/Users/user/_/workspace/lb-lab/ai-store-dkb/config/dimension_model_v0_1.json",
+  "directives": [
+    {
+      "directive_id": "agent-skills-official/anthropics/skills",
+      "preferred_name": "anthropics/skills",
+      "category": "agent-skills-official",
+      "source_label": "Anthropic public skills (E2E #10)",
+      "provenance_hint": "official",
+      "origin_uri": "https://github.com/anthropics/skills",
+      "collected_path": "/Users/user/_/workspace/lb-lab/ai-store-dkb/data/validation/e2e_collected/agent-skills-official/anthropics__skills.json",
+      "normalized_summary": "Public repository for Agent Skills",
+      "metadata": {
+        "repo": {
+          "full_name": "anthropics/skills",
+          "name": "skills",
+          "description": "Public repository for Agent Skills",
+          "stargazers_count": 106957,
+          "forks_count": 11837,
+          "language": "Python",
+          "license_spdx": null,
+          "topics": [
+            "agent-skills"
+          ],
+          "updated_at": "2026-03-31T07:10:45Z",
+          "owner_login": "anthropics",
+          "owner_type": "Organization",
+          "html_url": "https://github.com/anthropics/skills"
+        },
+        "readme_excerpt": "> **Note:** This repository contains Anthropic's implementation of skills for Claude. For information about the Agent Skills standard, see [agentskills.io](http://agentskills.io).\n\n# Skills\nSkills are folders of instructions, scripts, and resources that Claude loads dynamically to improve performance on specialized tasks. Skills teach Claude how to complete specific tasks in a repeatable way, whether that's creating documents with your company's brand guidelines, analyzing data using your organi",
+        "fetched_at": "2026-03-31T07:11:18.741234+00:00"
+      },
+      "scores": {
+        "form": {
+          "skillness": 0.75,
+          "agentness": 0.7166666666666667,
+          "workflowness": 0.15,
+          "commandness": 0.0,
+          "pluginness": 0.0
+        },
+        "function": {
+          "planning": 0.0,
+          "review": 0.0,
+          "coding": 0.5555555555555556,
+          "research": 0.0,
+          "ops": 0.0,
+          "writing": 0.6666666666666666,
+          "content": 0.0,
+          "orchestration": 0.0
+        },
+        "execution": {
+          "atomicity": 1.0,
+          "autonomy": 1.0,
+          "multi_stepness": 0.0,
+          "tool_dependence": 0.47619047619047616,
+          "composability": 0.0,
+          "reusability": 0.41666666666666663
+        },
+        "governance": {
+          "officialness": 0.9523809523809523,
+          "legal_clarity": 0.0,
+          "maintenance_health": 0.0,
+          "install_verifiability": 0.0,
+          "trustworthiness": 0.31746031746031744
+        },
+        "adoption": {
+          "star_signal": 0.4166666666666667,
+          "fork_signal": 0.4166666666666667,
+          "mention_signal": 0.0,
+          "install_signal": 0.0,
+          "freshness": 0.0
+        },
+        "clarity": {
+          "naming_clarity": 0.425,
+          "description_clarity": 0.395625,
+          "io_clarity": 0.0,
+          "example_coverage": 0.0,
+          "overlap_ambiguity_inverse": 1.0
+        }
+      },
+      "overall_score": 0.284,
+      "verdict": "caution"
+    },
+    {
+      "directive_id": "claude-code/hesreallyhim/awesome-claude-code",
+      "preferred_name": "hesreallyhim/awesome-claude-code",
+      "category": "claude-code",
+      "source_label": "Awesome Claude Code (E2E #11)",
+      "provenance_hint": "community",
+      "origin_uri": "https://github.com/hesreallyhim/awesome-claude-code",
+      "collected_path": "/Users/user/_/workspace/lb-lab/ai-store-dkb/data/validation/e2e_collected/claude-code/hesreallyhim__awesome-claude-code.json",
+      "normalized_summary": "A curated list of awesome skills, hooks, slash-commands, agent orchestrators, applications, and plugins for Claude Code by Anthropic",
+      "metadata": {
+        "repo": {
+          "full_name": "hesreallyhim/awesome-claude-code",
+          "name": "awesome-claude-code",
+          "description": "A curated list of awesome skills, hooks, slash-commands, agent orchestrators, applications, and plugins for Claude Code by Anthropic",
+          "stargazers_count": 34703,
+          "forks_count": 2523,
+          "language": "Python",
+          "license_spdx": "NOASSERTION",
+          "topics": [
+            "agent-skills",
+            "agentic-code",
+            "agentic-coding",
+            "ai-workflow-optimization",
+            "ai-workflows",
+            "anthropic",
+            "anthropic-claude",
+            "awesome",
+            "awesome-list",
+            "awesome-lists",
+            "awesome-resources",
+            "claude",
+            "claude-code",
+            "coding-agent",
+            "coding-agents",
+            "coding-assistant",
+            "coding-assistants",
+            "llm"
+          ],
+          "updated_at": "2026-03-31T07:11:07Z",
+          "owner_login": "hesreallyhim",
+          "owner_type": "User",
+          "html_url": "https://github.com/hesreallyhim/awesome-claude-code"
+        },
+        "readme_excerpt": "<!-- GENERATED FILE: do not edit directly -->\n<h3 align=\"center\">Pick Your Style:</h3>\n<p align=\"center\">\n<a href=\"./\"><img src=\"assets/badge-style-awesome.svg\" alt=\"Awesome\" height=\"28\" style=\"border: 2px solid #cc3366; border-radius: 4px;\"></a>\n<a href=\"README_ALTERNATIVES/README_EXTRA.md\"><img src=\"assets/badge-style-extra.svg\" alt=\"Extra\" height=\"28\"></a>\n<a href=\"README_ALTERNATIVES/README_CLASSIC.md\"><img src=\"assets/badge-style-classic.svg\" alt=\"Classic\" height=\"28\"></a>\n<a href=\"README_A",
+        "fetched_at": "2026-03-31T07:11:20.478919+00:00"
+      },
+      "scores": {
+        "form": {
+          "skillness": 0.45,
+          "agentness": 0.3666666666666667,
+          "workflowness": 0.7999999999999999,
+          "commandness": 0.47619047619047616,
+          "pluginness": 1.0
+        },
+        "function": {
+          "planning": 0.0,
+          "review": 0.0,
+          "coding": 0.5555555555555556,
+          "research": 0.0,
+          "ops": 0.0,
+          "writing": 0.0,
+          "content": 0.6666666666666666,
+          "orchestration": 0.0
+        },
+        "execution": {
+          "atomicity": 1.0,
+          "autonomy": 1.0,
+          "multi_stepness": 0.6666666666666666,
+          "tool_dependence": 0.0,
+          "composability": 0.0,
+          "reusability": 1.0
+        },
+        "governance": {
+          "officialness": 0.9523809523809523,
+          "legal_clarity": 0.0,
+          "maintenance_health": 0.0,
+          "install_verifiability": 0.0,
+          "trustworthiness": 0.31746031746031744
+        },
+        "adoption": {
+          "star_signal": 0.4166666666666667,
+          "fork_signal": 0.4166666666666667,
+          "mention_signal": 0.0,
+          "install_signal": 0.0,
+          "freshness": 0.0
+        },
+        "clarity": {
+          "naming_clarity": 0.8,
+          "description_clarity": 0.5,
+          "io_clarity": 0.0,
+          "example_coverage": 0.0,
+          "overlap_ambiguity_inverse": 1.0
+        }
+      },
+      "overall_score": 0.3643,
+      "verdict": "caution"
+    },
+    {
+      "directive_id": "mcp/modelcontextprotocol/servers",
+      "preferred_name": "modelcontextprotocol/servers",
+      "category": "mcp",
+      "source_label": "MCP official servers (E2E #12)",
+      "provenance_hint": "official",
+      "origin_uri": "https://github.com/modelcontextprotocol/servers",
+      "collected_path": "/Users/user/_/workspace/lb-lab/ai-store-dkb/data/validation/e2e_collected/mcp/modelcontextprotocol__servers.json",
+      "normalized_summary": "Model Context Protocol Servers",
+      "metadata": {
+        "repo": {
+          "full_name": "modelcontextprotocol/servers",
+          "name": "servers",
+          "description": "Model Context Protocol Servers",
+          "stargazers_count": 82573,
+          "forks_count": 10133,
+          "language": "TypeScript",
+          "license_spdx": "NOASSERTION",
+          "topics": [],
+          "updated_at": "2026-03-31T06:58:46Z",
+          "owner_login": "modelcontextprotocol",
+          "owner_type": "Organization",
+          "html_url": "https://github.com/modelcontextprotocol/servers"
+        },
+        "readme_excerpt": "# Model Context Protocol servers\n\nThis repository is a collection of *reference implementations* for the [Model Context Protocol](https://modelcontextprotocol.io/) (MCP), as well as references to community-built servers and additional resources.\n\n> [!IMPORTANT]\n> If you are looking for a list of MCP servers, you can browse published servers on [the MCP Registry](https://registry.modelcontextprotocol.io/). The repository served by this README is dedicated to housing just the small number of refer",
+        "fetched_at": "2026-03-31T07:11:22.840614+00:00"
+      },
+      "scores": {
+        "form": {
+          "skillness": 0.2,
+          "agentness": 0.2,
+          "workflowness": 0.15,
+          "commandness": 0.0,
+          "pluginness": 0.0
+        },
+        "function": {
+          "planning": 0.0,
+          "review": 0.0,
+          "coding": 0.5555555555555556,
+          "research": 0.0,
+          "ops": 0.0,
+          "writing": 0.0,
+          "content": 0.0,
+          "orchestration": 0.0
+        },
+        "execution": {
+          "atomicity": 1.0,
+          "autonomy": 1.0,
+          "multi_stepness": 0.0,
+          "tool_dependence": 0.9523809523809523,
+          "composability": 0.0,
+          "reusability": 0.41666666666666663
+        },
+        "governance": {
+          "officialness": 0.47619047619047616,
+          "legal_clarity": 0.0,
+          "maintenance_health": 0.0,
+          "install_verifiability": 0.0,
+          "trustworthiness": 0.15873015873015872
+        },
+        "adoption": {
+          "star_signal": 0.4166666666666667,
+          "fork_signal": 0.4166666666666667,
+          "mention_signal": 0.0,
+          "install_signal": 0.0,
+          "freshness": 0.0
+        },
+        "clarity": {
+          "naming_clarity": 0.7,
+          "description_clarity": 0.391875,
+          "io_clarity": 0.0,
+          "example_coverage": 0.0,
+          "overlap_ambiguity_inverse": 1.0
+        }
+      },
+      "overall_score": 0.2363,
+      "verdict": "caution"
+    }
+  ]
+}

--- a/data/validation/validation_report.json
+++ b/data/validation/validation_report.json
@@ -1,0 +1,38 @@
+{
+  "timestamp": "2026-03-31T07:11:23.686367+00:00",
+  "dimension_count_expected": 34,
+  "overall_ok": true,
+  "processed_path": "/Users/user/_/workspace/lb-lab/ai-store-dkb/data/validation/processed/directives.json",
+  "collected_dir": "/Users/user/_/workspace/lb-lab/ai-store-dkb/data/validation/e2e_collected",
+  "notes": [
+    "Issue #10: target anthropics/skills (official Anthropic public skills). The path anthropic/claude-code-skills is not a public GitHub repository as of validation.",
+    "Issue #11: hesreallyhim/awesome-claude-code",
+    "Issue #12: modelcontextprotocol/servers"
+  ],
+  "repos": [
+    {
+      "full_name": "anthropics/skills",
+      "github_issue": 10,
+      "ok": true,
+      "errors": [],
+      "overall_score": 0.284,
+      "verdict": "caution"
+    },
+    {
+      "full_name": "hesreallyhim/awesome-claude-code",
+      "github_issue": 11,
+      "ok": true,
+      "errors": [],
+      "overall_score": 0.3643,
+      "verdict": "caution"
+    },
+    {
+      "full_name": "modelcontextprotocol/servers",
+      "github_issue": 12,
+      "ok": true,
+      "errors": [],
+      "overall_score": 0.2363,
+      "verdict": "caution"
+    }
+  ]
+}

--- a/data/validation/validation_report.md
+++ b/data/validation/validation_report.md
@@ -1,0 +1,20 @@
+# E2E validation report
+
+- **UTC**: 2026-03-31T07:11:23.686367+00:00
+- **Overall**: PASS
+- **Dimensions**: 34 (DG v0.1 model)
+
+## Repositories
+
+- **anthropics/skills** (issue #10): PASS
+  - overall_score: 0.284, verdict: caution
+- **hesreallyhim/awesome-claude-code** (issue #11): PASS
+  - overall_score: 0.3643, verdict: caution
+- **modelcontextprotocol/servers** (issue #12): PASS
+  - overall_score: 0.2363, verdict: caution
+
+## Notes
+
+- Issue #10: target anthropics/skills (official Anthropic public skills). The path anthropic/claude-code-skills is not a public GitHub repository as of validation.
+- Issue #11: hesreallyhim/awesome-claude-code
+- Issue #12: modelcontextprotocol/servers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,9 @@ dev = [
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 
+[tool.hatch.metadata]
+allow-direct-references = true
+
 [tool.hatch.build.targets.wheel]
 packages = ["ai_store_dkb"]
 

--- a/scripts/build_catalog.py
+++ b/scripts/build_catalog.py
@@ -27,12 +27,18 @@ def git_sha(repo_root: Path) -> str:
     return "unknown"
 
 
-def flatten_scores_for_catalog(scores: dict[str, dict[str, float]]) -> dict[str, dict[str, Any]]:
+def flatten_scores_for_catalog(
+    scores: dict[str, dict[str, float]],
+) -> dict[str, dict[str, Any]]:
     """Catalog entries: dimension_key -> {score, dimension_group}."""
     out: dict[str, dict[str, Any]] = {}
     for group, dims in scores.items():
         for key, val in dims.items():
-            out[key] = {"score": round(float(val), 4), "dimension_group": group, "confidence": 0.7}
+            out[key] = {
+                "score": round(float(val), 4),
+                "dimension_group": group,
+                "confidence": 0.7,
+            }
     return out
 
 
@@ -85,7 +91,10 @@ def main(argv: list[str] | None = None) -> int:
             "scores_by_group": scores_nested,
             "verdict": {
                 "recommendation": d.get("verdict"),
-                "trust": "high" if (scores_nested.get("governance") or {}).get("trust", 0) >= 0.65 else "medium",
+                "trust": "high"
+                if (scores_nested.get("governance") or {}).get("trustworthiness", 0)
+                >= 0.65
+                else "medium",
             },
             "metadata": d.get("metadata"),
         }
@@ -105,7 +114,9 @@ def main(argv: list[str] | None = None) -> int:
     with open(out_path, "w", encoding="utf-8") as f:
         json.dump(catalog, f, indent=2)
 
-    print(f"Wrote {len(catalog_directives)} directives to {out_path} (build_id={build_id[:8]}...)")
+    print(
+        f"Wrote {len(catalog_directives)} directives to {out_path} (build_id={build_id[:8]}...)"
+    )
     return 0
 
 

--- a/scripts/build_report.py
+++ b/scripts/build_report.py
@@ -99,7 +99,9 @@ def print_summary(s: dict[str, Any]) -> None:
 
     od = s.get("overall_score_distribution") or {}
     print("\n=== Overall score distribution ===")
-    print(f"  min={od.get('min')} max={od.get('max')} avg={od.get('avg')} (n={od.get('count')})")
+    print(
+        f"  min={od.get('min')} max={od.get('max')} avg={od.get('avg')} (n={od.get('count')})"
+    )
 
     print("\n=== Score distribution by dimension ===")
     for dim, stats in sorted((s.get("score_distribution_by_dimension") or {}).items()):

--- a/scripts/collect_all.py
+++ b/scripts/collect_all.py
@@ -45,7 +45,9 @@ def iter_category_sources(
     return out
 
 
-def _default_provenance_for_category(sources_config: dict[str, Any], category_name: str) -> str | None:
+def _default_provenance_for_category(
+    sources_config: dict[str, Any], category_name: str
+) -> str | None:
     if not isinstance(sources_config.get("categories"), list):
         return None
     for c in sources_config["categories"]:
@@ -95,7 +97,10 @@ def main(argv: list[str] | None = None) -> None:
         pairs = [(c, s) for c, s in pairs if c in wanted]
         unknown = wanted - {c for c, _ in pairs}
         if unknown:
-            print(f"Warning: no sources found for categories: {', '.join(sorted(unknown))}", file=sys.stderr)
+            print(
+                f"Warning: no sources found for categories: {', '.join(sorted(unknown))}",
+                file=sys.stderr,
+            )
 
     grouped = _group_by_category(pairs)
     n_categories = len(grouped)
@@ -128,14 +133,20 @@ def main(argv: list[str] | None = None) -> None:
                     n_skipped += 1
                     continue
 
-                default_provenance = _default_provenance_for_category(sources_config, category_name)
+                default_provenance = _default_provenance_for_category(
+                    sources_config, category_name
+                )
                 provenance_hint = source_def.get("provenance_hint", default_provenance)
 
-                existing = db.scalars(select(Source).where(Source.origin_uri == origin_uri)).first()
+                existing = db.scalars(
+                    select(Source).where(Source.origin_uri == origin_uri)
+                ).first()
 
                 if args.dry_run:
                     if existing:
-                        print(f"    [DRY-RUN] would collect existing source (id={existing.source_id})")
+                        print(
+                            f"    [DRY-RUN] would collect existing source (id={existing.source_id})"
+                        )
                         n_dry_existing += 1
                     else:
                         print(

--- a/scripts/collect_github.py
+++ b/scripts/collect_github.py
@@ -26,7 +26,9 @@ def load_sources_config(path: Path) -> dict[str, Any]:
         return json.load(f)
 
 
-def iter_category_sources(sources_config: dict[str, Any]) -> list[tuple[str, dict[str, Any]]]:
+def iter_category_sources(
+    sources_config: dict[str, Any],
+) -> list[tuple[str, dict[str, Any]]]:
     out: list[tuple[str, dict[str, Any]]] = []
     categories = sources_config.get("categories", {})
     if isinstance(categories, dict):
@@ -68,7 +70,10 @@ def run_gh_api(path: str) -> tuple[int, dict[str, Any] | None, str]:
             timeout=120,
         )
     except FileNotFoundError:
-        print("ERROR: gh CLI not found. Install GitHub CLI and run `gh auth login`.", file=sys.stderr)
+        print(
+            "ERROR: gh CLI not found. Install GitHub CLI and run `gh auth login`.",
+            file=sys.stderr,
+        )
         return 127, None, ""
     except subprocess.TimeoutExpired:
         return 124, None, "timeout"
@@ -93,7 +98,9 @@ def fetch_readme_excerpt(owner: str, repo: str, max_chars: int = 500) -> str:
     if not b64:
         return ""
     try:
-        raw = base64.b64decode(b64.encode("ascii"), validate=False).decode("utf-8", errors="replace")
+        raw = base64.b64decode(b64.encode("ascii"), validate=False).decode(
+            "utf-8", errors="replace"
+        )
     except (ValueError, OSError):
         return ""
     raw = raw.strip()
@@ -102,12 +109,16 @@ def fetch_readme_excerpt(owner: str, repo: str, max_chars: int = 500) -> str:
     return raw[:max_chars]
 
 
-def fetch_repo_metadata(owner: str, repo: str) -> tuple[dict[str, Any] | None, str | None]:
+def fetch_repo_metadata(
+    owner: str, repo: str
+) -> tuple[dict[str, Any] | None, str | None]:
     api_path = f"repos/{owner}/{repo}"
     code, data, stderr = run_gh_api(api_path)
     if code != 0:
         hint = stderr[:200] if stderr else ""
-        err = f"gh api failed (exit {code}) for {api_path}" + (f": {hint}" if hint else "")
+        err = f"gh api failed (exit {code}) for {api_path}" + (
+            f": {hint}" if hint else ""
+        )
         return None, err
     return data, None
 
@@ -172,9 +183,13 @@ def main(argv: list[str] | None = None) -> int:
     cat_list = sorted(by_cat.items(), key=lambda x: x[0])
 
     for cat_idx, (category_name, source_list) in enumerate(cat_list, start=1):
-        limited = source_list[: args.limit] if args.limit and args.limit > 0 else source_list
+        limited = (
+            source_list[: args.limit] if args.limit and args.limit > 0 else source_list
+        )
         n = len(limited)
-        print(f"\n=== Category [{cat_idx}/{len(cat_list)}]: {category_name} ({n} sources) ===")
+        print(
+            f"\n=== Category [{cat_idx}/{len(cat_list)}]: {category_name} ({n} sources) ==="
+        )
         cat_dir = out_root / category_name
         cat_dir.mkdir(parents=True, exist_ok=True)
 

--- a/scripts/export_catalog.py
+++ b/scripts/export_catalog.py
@@ -38,7 +38,9 @@ def main() -> None:
 
         for d in directives:
             scores = db.scalars(
-                select(DimensionScore).where(DimensionScore.directive_id == d.directive_id)
+                select(DimensionScore).where(
+                    DimensionScore.directive_id == d.directive_id
+                )
             ).all()
             verdict = db.scalars(
                 select(Verdict)
@@ -52,7 +54,8 @@ def main() -> None:
                 "normalized_summary": d.normalized_summary,
                 "status": d.status,
                 "scores": {
-                    s.dimension_key: {"score": s.score, "confidence": s.confidence} for s in scores
+                    s.dimension_key: {"score": s.score, "confidence": s.confidence}
+                    for s in scores
                 },
                 "verdict": {
                     "provenance": verdict.provenance_state,

--- a/scripts/process_collected.py
+++ b/scripts/process_collected.py
@@ -5,178 +5,19 @@ from __future__ import annotations
 
 import argparse
 import json
-import math
-import re
 import sys
 from pathlib import Path
 from typing import Any
 
-# Heuristic keyword buckets (lowercase matching)
-SKILL_HINTS = re.compile(
-    r"\b(skill|skills|agent|mcp|plugin|plugins|claude|cursor|codex|gemini|subagent|"
-    r"prompt|directive|awesome|rules?|workflow)\b",
-    re.I,
-)
-WORKFLOW_HINTS = re.compile(
-    r"\b(workflow|automation|ci|cd|pipeline|orchestrat|playbook|runbook|process)\b",
-    re.I,
-)
-TOOL_HINTS = re.compile(
-    r"\b(tool|tools|mcp|api|cli|sdk|server|servers|integration|connector)\b",
-    re.I,
-)
-CODING_README = re.compile(
-    r"\b(install|npm|pip|pnpm|yarn|cargo|go install|clone|docker|compose|build|"
-    r"typescript|python|rust|```)\b",
-    re.I,
-)
-REVIEW_README = re.compile(
-    r"\b(review|pr|pull request|lint|test|coverage|ci|codecov|eslint|ruff)\b",
-    re.I,
-)
-PLANNING_README = re.compile(
-    r"\b(plan|roadmap|architecture|design|rfc|todo|backlog|milestone|strategy)\b",
-    re.I,
-)
+from dkb_runtime.services.scoring import _clamp01, _score_dimension
 
-TRUST_ORGS = frozenset(
-    {
-        "anthropics",
-        "microsoft",
-        "google",
-        "google-gemini",
-        "google-labs-code",
-        "vercel-labs",
-        "modelcontextprotocol",
-        "openclaw",
-        "github",
-    }
-)
-
-PERMISSIVE_LICENSES = frozenset(
-    {
-        "MIT",
-        "Apache-2.0",
-        "BSD-2-Clause",
-        "BSD-3-Clause",
-        "ISC",
-        "Unlicense",
-        "0BSD",
-        "CC0-1.0",
-    }
-)
-COPYLEFT_LICENSES = frozenset({"GPL-3.0", "GPL-2.0", "AGPL-3.0", "LGPL-3.0", "LGPL-2.1", "MPL-2.0"})
+_ROOT = Path(__file__).resolve().parent.parent
+_DIMENSION_MODEL_PATH = _ROOT / "config" / "dimension_model_v0_1.json"
 
 
-def clamp01(x: float) -> float:
-    return max(0.0, min(1.0, x))
-
-
-def score_topics_description(description: str, topics: list[str]) -> tuple[float, float, float]:
-    text = f"{description} {' '.join(topics)}".lower()
-    skill = 0.25
-    if SKILL_HINTS.search(text):
-        skill += 0.35
-    if "awesome" in text or "list" in text:
-        skill += 0.15
-    if len(topics) >= 5:
-        skill += 0.15
-    wf = 0.2
-    if WORKFLOW_HINTS.search(text):
-        wf += 0.45
-    if "automation" in text or "workflow" in topics:
-        wf += 0.2
-    tool = 0.2
-    if TOOL_HINTS.search(text):
-        tool += 0.45
-    if any(t in ("mcp", "cli", "api") for t in topics):
-        tool += 0.2
-    return clamp01(skill), clamp01(wf), clamp01(tool)
-
-
-def score_readme_function(readme: str) -> tuple[float, float, float]:
-    if not readme.strip():
-        return 0.15, 0.1, 0.1
-    coding = 0.2
-    if CODING_README.search(readme):
-        coding += 0.35
-    if readme.count("```") >= 2:
-        coding += 0.25
-    if len(readme) > 800:
-        coding += 0.1
-    review = 0.15
-    if REVIEW_README.search(readme):
-        review += 0.45
-    plan = 0.15
-    if PLANNING_README.search(readme):
-        plan += 0.45
-    if len(readme) > 1500:
-        plan += 0.1
-    return clamp01(coding), clamp01(review), clamp01(plan)
-
-
-def score_installability(license_spdx: str | None, language: str | None) -> float:
-    base = 0.35
-    if language:
-        base += 0.25
-    if not license_spdx or license_spdx in ("NOASSERTION", "NONE"):
-        return clamp01(base * 0.6)
-    if license_spdx in PERMISSIVE_LICENSES:
-        base += 0.35
-    elif license_spdx in COPYLEFT_LICENSES:
-        base += 0.2
-    else:
-        base += 0.15
-    return clamp01(base)
-
-
-def score_trust(stars: int, owner_login: str | None, owner_type: str | None, provenance: str | None) -> float:
-    s = 0.25
-    if stars >= 5000:
-        s += 0.35
-    elif stars >= 1000:
-        s += 0.28
-    elif stars >= 200:
-        s += 0.18
-    elif stars >= 50:
-        s += 0.1
-    ol = (owner_login or "").lower()
-    if ol in TRUST_ORGS:
-        s += 0.2
-    if owner_type == "Organization":
-        s += 0.08
-    if provenance == "official":
-        s += 0.12
-    return clamp01(s)
-
-
-def score_popularity(stars: int, forks: int) -> float:
-    # Log-scaled blend
-    if stars <= 0 and forks <= 0:
-        return 0.12
-    ls = math.log1p(stars)
-    lf = math.log1p(forks)
-    combined = (ls * 0.75 + lf * 0.25) / math.log1p(20000)
-    return clamp01(combined)
-
-
-def score_description_clarity(description: str) -> float:
-    d = (description or "").strip()
-    n = len(d)
-    if n < 20:
-        return 0.15
-    if n < 40:
-        return 0.35
-    score = 0.45
-    if 60 <= n <= 400:
-        score += 0.3
-    elif n > 400:
-        score += 0.15
-    if any(c in d for c in ".:,-"):
-        score += 0.1
-    if d[0].isupper():
-        score += 0.05
-    return clamp01(score)
+def load_dimension_groups(config_path: Path) -> list[tuple[str, list[str]]]:
+    data = json.loads(config_path.read_text(encoding="utf-8"))
+    return [(g["name"], list(g["dimensions"])) for g in data["groups"]]
 
 
 def overall_average(scores: dict[str, dict[str, float]]) -> float:
@@ -196,13 +37,54 @@ def verdict_from_scores(avg: float, trust: float, installability: float) -> str:
     return "neutral"
 
 
+def build_scoring_context(
+    data: dict[str, Any], repo: dict[str, Any]
+) -> tuple[str, str, str]:
+    desc = repo.get("description") or ""
+    topics = list(repo.get("topics") or [])
+    readme = data.get("readme_excerpt") or ""
+    full = repo.get("full_name") or ""
+    name = repo.get("name") or ""
+    stars = int(repo.get("stargazers_count") or 0)
+    forks = int(repo.get("forks_count") or 0)
+    lic = repo.get("license_spdx") or ""
+
+    parts = [full, name, desc, " ".join(topics), readme]
+    parts.append(f"github repository stargazers_count={stars} forks_count={forks}")
+    if lic and str(lic).upper() not in ("NOASSERTION", "NONE", ""):
+        parts.append(f"license {lic}")
+
+    content = "\n".join(p for p in parts if p)
+    path_blob = f"{full.lower()} {' '.join(topics).lower()}"
+    type_blob = (data.get("category") or "").lower()
+    return content, path_blob, type_blob
+
+
+def score_directive_from_context(
+    content: str,
+    path_blob: str,
+    type_blob: str,
+    dimension_config: Path,
+) -> dict[str, dict[str, float]]:
+    groups = load_dimension_groups(dimension_config)
+    scores: dict[str, dict[str, float]] = {}
+    for group_name, dims in groups:
+        scores[group_name] = {}
+        for dim_key in dims:
+            s, _conf, _ex = _score_dimension(
+                group_name, dim_key, content, path_blob, type_blob
+            )
+            scores[group_name][dim_key] = _clamp01(float(s))
+    return scores
+
+
 def load_collected_files(root: Path) -> list[Path]:
     if not root.is_dir():
         return []
     return sorted(p for p in root.rglob("*.json") if p.is_file())
 
 
-def directive_from_file(path: Path) -> dict[str, Any] | None:
+def directive_from_file(path: Path, dimension_config: Path) -> dict[str, Any] | None:
     try:
         with open(path, encoding="utf-8") as f:
             data = json.load(f)
@@ -212,35 +94,26 @@ def directive_from_file(path: Path) -> dict[str, Any] | None:
         return None
     repo = data["repo"]
     desc = repo.get("description") or ""
-    topics = list(repo.get("topics") or [])
     readme = data.get("readme_excerpt") or ""
-    stars = int(repo.get("stargazers_count") or 0)
-    forks = int(repo.get("forks_count") or 0)
-    lic = repo.get("license_spdx")
-    lang = repo.get("language")
-    owner_login = repo.get("owner_login")
-    owner_type = repo.get("owner_type")
-    provenance = data.get("provenance_hint")
 
-    sk, wf, tl = score_topics_description(desc, topics)
-    cd, rv, pl = score_readme_function(readme)
-    inst = score_installability(lic, lang)
-    trust = score_trust(stars, owner_login, owner_type, provenance)
-    pop = score_popularity(stars, forks)
-    clar = score_description_clarity(desc)
+    if not dimension_config.is_file():
+        print(f"ERROR: dimension model missing: {dimension_config}", file=sys.stderr)
+        return None
 
-    scores: dict[str, dict[str, float]] = {
-        "form": {"skillness": sk, "workflowness": wf, "toolness": tl},
-        "function": {"coding": cd, "review": rv, "planning": pl},
-        "execution": {"installability": inst},
-        "governance": {"trust": trust},
-        "adoption": {"popularity": pop},
-        "clarity": {"description_clarity": clar},
-    }
+    content, path_blob, type_blob = build_scoring_context(data, repo)
+    scores = score_directive_from_context(
+        content, path_blob, type_blob, dimension_config
+    )
+
+    gov = scores.get("governance") or {}
+    trust = float(gov.get("trustworthiness", 0.0))
+    inst = float(gov.get("install_verifiability", 0.0))
     avg = overall_average(scores)
     verdict = verdict_from_scores(avg, trust, inst)
 
     directive_id = f"{data.get('category')}/{repo.get('full_name', path.stem)}"
+
+    provenance = data.get("provenance_hint")
 
     return {
         "directive_id": directive_id,
@@ -277,11 +150,18 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=root / "storage" / "processed" / "directives.json",
         help="Output directives JSON path",
     )
+    p.add_argument(
+        "--dimension-model",
+        type=Path,
+        default=root / "config" / "dimension_model_v0_1.json",
+        help="Path to dimension_model_v0_1.json (34 DG dimensions)",
+    )
     return p.parse_args(argv)
 
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
+    dim_cfg = args.dimension_model
     files = load_collected_files(args.input)
     if not files:
         print(f"No JSON files under {args.input}", file=sys.stderr)
@@ -290,7 +170,7 @@ def main(argv: list[str] | None = None) -> int:
     directives: list[dict[str, Any]] = []
     skipped = 0
     for p in files:
-        d = directive_from_file(p)
+        d = directive_from_file(p, dim_cfg)
         if d:
             directives.append(d)
         else:
@@ -298,14 +178,17 @@ def main(argv: list[str] | None = None) -> int:
 
     args.output.parent.mkdir(parents=True, exist_ok=True)
     payload = {
-        "version": "0.1.0",
+        "version": "0.2.0",
         "directive_count": len(directives),
+        "dimension_model_path": str(dim_cfg),
         "directives": directives,
     }
     with open(args.output, "w", encoding="utf-8") as f:
         json.dump(payload, f, indent=2)
 
-    print(f"Processed {len(directives)} directives (skipped {skipped} files) -> {args.output}")
+    print(
+        f"Processed {len(directives)} directives (skipped {skipped} files) -> {args.output}"
+    )
     return 0
 
 

--- a/scripts/report.py
+++ b/scripts/report.py
@@ -51,7 +51,10 @@ def origin_uri_to_category(sources_config: dict[str, Any]) -> dict[str, str]:
 
 def _latest_verdict_subquery():
     return (
-        select(Verdict.directive_id.label("directive_id"), func.max(Verdict.evaluated_at).label("mx"))
+        select(
+            Verdict.directive_id.label("directive_id"),
+            func.max(Verdict.evaluated_at).label("mx"),
+        )
         .group_by(Verdict.directive_id)
         .subquery()
     )
@@ -95,12 +98,24 @@ def build_report(db, sources_config_path: Path) -> dict[str, Any]:
     v_alias = Verdict
     trust_stmt = (
         select(v_alias.trust_state, func.count())
-        .join(mx, and_(v_alias.directive_id == mx.c.directive_id, v_alias.evaluated_at == mx.c.mx))
+        .join(
+            mx,
+            and_(
+                v_alias.directive_id == mx.c.directive_id,
+                v_alias.evaluated_at == mx.c.mx,
+            ),
+        )
         .group_by(v_alias.trust_state)
     )
     rec_stmt = (
         select(v_alias.recommendation_state, func.count())
-        .join(mx, and_(v_alias.directive_id == mx.c.directive_id, v_alias.evaluated_at == mx.c.mx))
+        .join(
+            mx,
+            and_(
+                v_alias.directive_id == mx.c.directive_id,
+                v_alias.evaluated_at == mx.c.mx,
+            ),
+        )
         .group_by(v_alias.recommendation_state)
     )
     verdict_trust = {row[0]: int(row[1]) for row in db.execute(trust_stmt).all()}
@@ -122,12 +137,15 @@ def build_report(db, sources_config_path: Path) -> dict[str, Any]:
         .limit(10)
     )
     top_directives = [
-        {"preferred_name": row[0], "avg_score": float(row[1])} for row in db.execute(top_stmt).all()
+        {"preferred_name": row[0], "avg_score": float(row[1])}
+        for row in db.execute(top_stmt).all()
     ]
 
     return {
         "source_count_by_category": dict(sorted(by_category.items())),
-        "directive_count_by_declared_type": dict(sorted(by_declared_type.items(), key=lambda x: (-x[1], x[0]))),
+        "directive_count_by_declared_type": dict(
+            sorted(by_declared_type.items(), key=lambda x: (-x[1], x[0]))
+        ),
         "score_distribution_by_dimension_group": score_by_group,
         "verdict_distribution": {
             "trust_state": dict(sorted(verdict_trust.items())),

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -13,7 +13,12 @@ from sqlalchemy import create_engine, select
 from sqlalchemy.orm import sessionmaker
 
 from dkb_runtime.core.config import get_settings
-from dkb_runtime.models import CanonicalDirective, DimensionModel, RawDirective, SourceSnapshot
+from dkb_runtime.models import (
+    CanonicalDirective,
+    DimensionModel,
+    RawDirective,
+    SourceSnapshot,
+)
 from dkb_runtime.services.canonicalizer import CanonicalResult, canonicalize
 from dkb_runtime.services.extractor import extract_directives
 from dkb_runtime.services.scoring import score_directive
@@ -69,10 +74,16 @@ def _raw_ids_for_captured_snapshots(db) -> list[UUID]:
 
 def _load_active_canonicals(db) -> list[CanonicalResult]:
     rows = db.scalars(
-        select(CanonicalDirective).where(CanonicalDirective.status == "active").order_by(CanonicalDirective.preferred_name)
+        select(CanonicalDirective)
+        .where(CanonicalDirective.status == "active")
+        .order_by(CanonicalDirective.preferred_name)
     ).all()
     return [
-        CanonicalResult(directive_id=r.directive_id, preferred_name=r.preferred_name, mapped_raw_count=0)
+        CanonicalResult(
+            directive_id=r.directive_id,
+            preferred_name=r.preferred_name,
+            mapped_raw_count=0,
+        )
         for r in rows
     ]
 
@@ -95,7 +106,10 @@ def main(argv: list[str] | None = None) -> None:
         ).first()
         if "score" in stages or "verdict" in stages:
             if not dimension_model:
-                print("ERROR: No active dimension model found. Run seed first.", file=sys.stderr)
+                print(
+                    "ERROR: No active dimension model found. Run seed first.",
+                    file=sys.stderr,
+                )
                 return
 
         print(f"Stages: {' -> '.join(stages)}\n")
@@ -111,20 +125,32 @@ def main(argv: list[str] | None = None) -> None:
             n_snap = len(snapshots)
             print(f"Found {n_snap} captured snapshots to extract from")
             for i, snapshot in enumerate(snapshots, start=1):
-                print(f"  Extracting snapshot [{i}/{n_snap}] {snapshot.snapshot_id} ...")
+                print(
+                    f"  Extracting snapshot [{i}/{n_snap}] {snapshot.snapshot_id} ..."
+                )
                 results = extract_directives(db, snapshot.snapshot_id)
                 all_raw_ids.extend(r.raw_directive_id for r in results)
-                print(f"    extracted {len(results)} raw directives (running total raw: {len(all_raw_ids)})")
+                print(
+                    f"    extracted {len(results)} raw directives (running total raw: {len(all_raw_ids)})"
+                )
             elapsed = time.perf_counter() - t0
             stage_stats.append(
-                StageStats("extract", elapsed, f"{n_snap} snapshots, {len(all_raw_ids)} raw directive rows")
+                StageStats(
+                    "extract",
+                    elapsed,
+                    f"{n_snap} snapshots, {len(all_raw_ids)} raw directive rows",
+                )
             )
             print(f"  (extract done in {elapsed:.2f}s)\n")
 
         if "canonicalize" in stages:
             t0 = time.perf_counter()
             print("=== Stage: canonicalize ===")
-            raw_ids = list(all_raw_ids) if all_raw_ids else _raw_ids_for_captured_snapshots(db)
+            raw_ids = (
+                list(all_raw_ids)
+                if all_raw_ids
+                else _raw_ids_for_captured_snapshots(db)
+            )
             if not all_raw_ids:
                 all_raw_ids = raw_ids
             print(f"Canonicalizing {len(raw_ids)} raw directives ...")
@@ -132,14 +158,20 @@ def main(argv: list[str] | None = None) -> None:
             print(f"  created/updated {len(canonical_results)} canonical directives")
             elapsed = time.perf_counter() - t0
             stage_stats.append(
-                StageStats("canonicalize", elapsed, f"{len(canonical_results)} canonical directives")
+                StageStats(
+                    "canonicalize",
+                    elapsed,
+                    f"{len(canonical_results)} canonical directives",
+                )
             )
             print(f"  (canonicalize done in {elapsed:.2f}s)\n")
 
         if "score" in stages:
             t0 = time.perf_counter()
             print("=== Stage: score ===")
-            targets = canonical_results if canonical_results else _load_active_canonicals(db)
+            targets = (
+                canonical_results if canonical_results else _load_active_canonicals(db)
+            )
             n = len(targets)
             print(f"Scoring {n} canonical directives ...")
             for i, cr in enumerate(targets, start=1):
@@ -147,7 +179,9 @@ def main(argv: list[str] | None = None) -> None:
                     print(f"\n  --- Scoring: {cr.preferred_name} ---")
                 elif i == 1 or i == n or i % 25 == 0:
                     print(f"  scoring [{i}/{n}] ...")
-                scores = score_directive(db, cr.directive_id, dimension_model.dimension_model_id)
+                scores = score_directive(
+                    db, cr.directive_id, dimension_model.dimension_model_id
+                )
                 if args.verbose:
                     print(f"    scored {len(scores)} dimensions")
             elapsed = time.perf_counter() - t0
@@ -157,7 +191,9 @@ def main(argv: list[str] | None = None) -> None:
         if "verdict" in stages:
             t0 = time.perf_counter()
             print("=== Stage: verdict ===")
-            targets = canonical_results if canonical_results else _load_active_canonicals(db)
+            targets = (
+                canonical_results if canonical_results else _load_active_canonicals(db)
+            )
             n = len(targets)
             print(f"Evaluating verdicts for {n} canonical directives ...")
             for i, cr in enumerate(targets, start=1):
@@ -167,7 +203,9 @@ def main(argv: list[str] | None = None) -> None:
                     print(f"  verdict [{i}/{n}] ...")
                 verdict = evaluate_directive(db, cr.directive_id)
                 if args.verbose:
-                    print(f"    Verdict: trust={verdict.trust_state}, rec={verdict.recommendation_state}")
+                    print(
+                        f"    Verdict: trust={verdict.trust_state}, rec={verdict.recommendation_state}"
+                    )
             elapsed = time.perf_counter() - t0
             stage_stats.append(StageStats("verdict", elapsed, f"{n} directives"))
             print(f"  (verdict done in {elapsed:.2f}s)\n")

--- a/scripts/validate_e2e.py
+++ b/scripts/validate_e2e.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""E2E validation: collect three target repos, run the file-based pipeline, check 34 DG dimensions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPTS = _ROOT / "scripts"
+_DEFAULT_SOURCES = _ROOT / "config" / "e2e_validation_sources.json"
+_DEFAULT_COLLECTED = _ROOT / "data" / "validation" / "e2e_collected"
+_DEFAULT_PROCESSED = _ROOT / "data" / "validation" / "processed" / "directives.json"
+_DEFAULT_REPORT_DIR = _ROOT / "data" / "validation"
+_DIMENSION_MODEL = _ROOT / "config" / "dimension_model_v0_1.json"
+
+REQUIRED_DIRECTIVE_FIELDS = (
+    "directive_id",
+    "preferred_name",
+    "category",
+    "source_label",
+    "provenance_hint",
+    "origin_uri",
+    "scores",
+    "overall_score",
+    "verdict",
+    "metadata",
+)
+
+
+@dataclass
+class RepoResult:
+    full_name: str
+    issue: int
+    ok: bool
+    errors: list[str] = field(default_factory=list)
+    directive: dict[str, Any] | None = None
+
+
+def load_dimension_expectations(path: Path) -> tuple[int, dict[str, list[str]]]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    groups = data["groups"]
+    by_group: dict[str, list[str]] = {g["name"]: list(g["dimensions"]) for g in groups}
+    n = sum(len(v) for v in by_group.values())
+    return n, by_group
+
+
+def run_subprocess(cmd: list[str], cwd: Path) -> tuple[int, str]:
+    proc = subprocess.run(
+        cmd, cwd=str(cwd), capture_output=True, text=True, timeout=600
+    )
+    out = (proc.stdout or "") + (proc.stderr or "")
+    return proc.returncode, out
+
+
+def collect_sources(
+    sources_path: Path,
+    out_dir: Path,
+    delay: float,
+) -> tuple[int, str]:
+    cmd = [
+        sys.executable,
+        str(_SCRIPTS / "collect_github.py"),
+        "--sources",
+        str(sources_path),
+        "--out",
+        str(out_dir),
+        "--delay",
+        str(delay),
+    ]
+    return run_subprocess(cmd, _ROOT)
+
+
+def process_collected(
+    collected_dir: Path,
+    processed_path: Path,
+    dimension_model: Path,
+) -> tuple[int, str]:
+    cmd = [
+        sys.executable,
+        str(_SCRIPTS / "process_collected.py"),
+        "--input",
+        str(collected_dir),
+        "--output",
+        str(processed_path),
+        "--dimension-model",
+        str(dimension_model),
+    ]
+    return run_subprocess(cmd, _ROOT)
+
+
+def validate_scores(
+    scores: dict[str, dict[str, Any]],
+    expected: dict[str, list[str]],
+) -> list[str]:
+    errs: list[str] = []
+    for group, keys in expected.items():
+        if group not in scores:
+            errs.append(f"missing score group {group!r}")
+            continue
+        gmap = scores[group]
+        for k in keys:
+            if k not in gmap:
+                errs.append(f"missing dimension {group}.{k}")
+                continue
+            v = gmap[k]
+            if not isinstance(v, (int, float)):
+                errs.append(f"non-numeric {group}.{k}={v!r}")
+                continue
+            if not (0.0 <= float(v) <= 1.0):
+                errs.append(f"out of range [0,1] {group}.{k}={v}")
+    for group in scores:
+        if group not in expected:
+            errs.append(f"unexpected score group {group!r}")
+    return errs
+
+
+def validate_directive(
+    d: dict[str, Any],
+    expected: dict[str, list[str]],
+) -> list[str]:
+    errs: list[str] = []
+    for f in REQUIRED_DIRECTIVE_FIELDS:
+        if f not in d or d[f] is None:
+            errs.append(f"missing required field {f!r}")
+    scores = d.get("scores")
+    if not isinstance(scores, dict):
+        errs.append("scores must be a dict")
+        return errs
+    errs.extend(validate_scores(scores, expected))
+    os_ = d.get("overall_score")
+    if not isinstance(os_, (int, float)) or not (0.0 <= float(os_) <= 1.0):
+        errs.append(f"overall_score invalid: {os_!r}")
+    if d.get("verdict") not in ("recommended", "neutral", "caution"):
+        errs.append(f"verdict invalid: {d.get('verdict')!r}")
+    return errs
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--sources",
+        type=Path,
+        default=_DEFAULT_SOURCES,
+        help="Fragment sources.json for collect_github.py",
+    )
+    p.add_argument(
+        "--collected-dir",
+        type=Path,
+        default=_DEFAULT_COLLECTED,
+        help="Directory for collected JSON (per category)",
+    )
+    p.add_argument(
+        "--processed",
+        type=Path,
+        default=_DEFAULT_PROCESSED,
+        help="Output path for process_collected.py",
+    )
+    p.add_argument(
+        "--report-dir",
+        type=Path,
+        default=_DEFAULT_REPORT_DIR,
+        help="Directory for validation_report.json / .md",
+    )
+    p.add_argument(
+        "--dimension-model",
+        type=Path,
+        default=_DIMENSION_MODEL,
+    )
+    p.add_argument(
+        "--skip-collect",
+        action="store_true",
+        help="Reuse existing --collected-dir (no gh api)",
+    )
+    p.add_argument(
+        "--delay",
+        type=float,
+        default=0.35,
+        help="Delay between GitHub API calls when collecting",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    n_expected, expected_groups = load_dimension_expectations(args.dimension_model)
+    if n_expected != 34:
+        print(
+            f"ERROR: expected 34 dimensions, found {n_expected} in {args.dimension_model}",
+            file=sys.stderr,
+        )
+        return 1
+
+    args.report_dir.mkdir(parents=True, exist_ok=True)
+    args.collected_dir.mkdir(parents=True, exist_ok=True)
+    args.processed.parent.mkdir(parents=True, exist_ok=True)
+
+    notes = [
+        "Issue #10: target anthropics/skills (official Anthropic public skills). "
+        "The path anthropic/claude-code-skills is not a public GitHub repository as of validation.",
+        "Issue #11: hesreallyhim/awesome-claude-code",
+        "Issue #12: modelcontextprotocol/servers",
+    ]
+
+    if not args.skip_collect:
+        if not args.sources.is_file():
+            print(f"ERROR: sources file not found: {args.sources}", file=sys.stderr)
+            return 1
+        code, out = collect_sources(args.sources, args.collected_dir, args.delay)
+        if code != 0:
+            print(out, file=sys.stderr)
+            print(f"ERROR: collect_github.py exited {code}", file=sys.stderr)
+            return code
+
+    code, out = process_collected(
+        args.collected_dir, args.processed, args.dimension_model
+    )
+    if code != 0:
+        print(out, file=sys.stderr)
+        print(f"ERROR: process_collected.py exited {code}", file=sys.stderr)
+        return code
+
+    with open(args.processed, encoding="utf-8") as f:
+        bundle = json.load(f)
+
+    directives = bundle.get("directives") or []
+    issue_by_name = {
+        "anthropics/skills": 10,
+        "hesreallyhim/awesome-claude-code": 11,
+        "modelcontextprotocol/servers": 12,
+    }
+
+    repo_results: list[RepoResult] = []
+    all_ok = True
+
+    for d in directives:
+        name = d.get("preferred_name") or ""
+        iss = issue_by_name.get(name, 0)
+        errs = validate_directive(d, expected_groups)
+        ok = not errs
+        all_ok = all_ok and ok
+        repo_results.append(
+            RepoResult(full_name=name, issue=iss, ok=ok, errors=errs, directive=d)
+        )
+
+    missing = set(issue_by_name) - {r.full_name for r in repo_results}
+    for fn in sorted(missing):
+        all_ok = False
+        repo_results.append(
+            RepoResult(
+                full_name=fn,
+                issue=issue_by_name[fn],
+                ok=False,
+                errors=[f"no directive produced for {fn} (collect or process failed)"],
+            )
+        )
+
+    ts = datetime.now(timezone.utc).isoformat()
+    report = {
+        "timestamp": ts,
+        "dimension_count_expected": n_expected,
+        "overall_ok": all_ok,
+        "processed_path": str(args.processed),
+        "collected_dir": str(args.collected_dir),
+        "notes": notes,
+        "repos": [
+            {
+                "full_name": r.full_name,
+                "github_issue": r.issue,
+                "ok": r.ok,
+                "errors": r.errors,
+                "overall_score": (r.directive or {}).get("overall_score"),
+                "verdict": (r.directive or {}).get("verdict"),
+            }
+            for r in sorted(repo_results, key=lambda x: x.issue or 99)
+        ],
+    }
+
+    json_path = args.report_dir / "validation_report.json"
+    with open(json_path, "w", encoding="utf-8") as f:
+        json.dump(report, f, indent=2)
+
+    md_lines = [
+        "# E2E validation report",
+        "",
+        f"- **UTC**: {ts}",
+        f"- **Overall**: {'PASS' if all_ok else 'FAIL'}",
+        f"- **Dimensions**: {n_expected} (DG v0.1 model)",
+        "",
+        "## Repositories",
+        "",
+    ]
+    for row in report["repos"]:
+        status = "PASS" if row["ok"] else "FAIL"
+        md_lines.append(
+            f"- **{row['full_name']}** (issue #{row['github_issue']}): {status}"
+        )
+        if row.get("overall_score") is not None:
+            md_lines.append(
+                f"  - overall_score: {row['overall_score']}, verdict: {row.get('verdict')}"
+            )
+        for e in row.get("errors") or []:
+            md_lines.append(f"  - ERROR: {e}")
+    md_lines.extend(["", "## Notes", ""])
+    for n in notes:
+        md_lines.append(f"- {n}")
+
+    md_path = args.report_dir / "validation_report.md"
+    md_path.write_text("\n".join(md_lines) + "\n", encoding="utf-8")
+
+    print(f"Wrote {json_path} and {md_path}")
+    if not all_ok:
+        print("VALIDATION FAILED", file=sys.stderr)
+        for r in repo_results:
+            if not r.ok:
+                print(f"  {r.full_name}: {r.errors}", file=sys.stderr)
+        return 1
+
+    print("VALIDATION OK (3 repos, 34 dimensions each)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import sys
 from pathlib import Path
 
 import pytest
@@ -12,9 +13,11 @@ ROOT = Path(__file__).resolve().parent.parent
 
 def _load_run_pipeline():
     path = ROOT / "scripts" / "run_pipeline.py"
-    spec = importlib.util.spec_from_file_location("run_pipeline", path)
+    name = "run_pipeline_test_mod"
+    spec = importlib.util.spec_from_file_location(name, path)
     assert spec and spec.loader
     mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
     spec.loader.exec_module(mod)
     return mod
 

--- a/tests/test_process_collected.py
+++ b/tests/test_process_collected.py
@@ -1,0 +1,73 @@
+"""Tests for file-based process_collected (34 DG dimensions)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture
+def dimension_model_path() -> Path:
+    p = ROOT / "config" / "dimension_model_v0_1.json"
+    assert p.is_file()
+    return p
+
+
+def test_dimension_model_has_34_leaves(dimension_model_path: Path) -> None:
+    data = json.loads(dimension_model_path.read_text(encoding="utf-8"))
+    n = sum(len(g["dimensions"]) for g in data["groups"])
+    assert n == 34
+
+
+def test_directive_from_file_scores_34_dimensions(
+    dimension_model_path: Path,
+    tmp_path: Path,
+) -> None:
+    path = ROOT / "scripts" / "process_collected.py"
+    name = "process_collected_test_mod"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+
+    sample = {
+        "category": "mcp",
+        "source_label": "test",
+        "provenance_hint": "official",
+        "origin_uri": "https://github.com/modelcontextprotocol/servers",
+        "fetched_at": "2026-01-01T00:00:00Z",
+        "error": None,
+        "repo": {
+            "full_name": "modelcontextprotocol/servers",
+            "name": "servers",
+            "description": "Model Context Protocol servers",
+            "stargazers_count": 5000,
+            "forks_count": 500,
+            "language": "TypeScript",
+            "license_spdx": "MIT",
+            "topics": ["mcp", "agents"],
+            "updated_at": "2026-01-01T00:00:00Z",
+            "owner_login": "modelcontextprotocol",
+            "owner_type": "Organization",
+            "html_url": "https://github.com/modelcontextprotocol/servers",
+        },
+        "readme_excerpt": "```bash\nnpm install\n```\nRun an MCP server.",
+    }
+    fp = tmp_path / "mcp__servers.json"
+    fp.write_text(json.dumps(sample), encoding="utf-8")
+
+    d = mod.directive_from_file(fp, dimension_model_path)
+    assert d is not None
+    scores = d["scores"]
+    flat = [v for g in scores.values() for v in g.values()]
+    assert len(flat) == 34
+    for v in flat:
+        assert 0.0 <= float(v) <= 1.0
+    assert d["verdict"] in ("recommended", "neutral", "caution")


### PR DESCRIPTION
## Summary
- File-based `process_collected.py` now scores all **34** DG dimensions using `dkb_runtime` rule scoring and `config/dimension_model_v0_1.json`.
- New `scripts/validate_e2e.py` runs `collect_github.py` on three targets, processes output, and writes `data/validation/validation_report.{json,md}`.
- **Issue #10**: validates `anthropics/skills` (official Anthropic skills). The path `anthropic/claude-code-skills` is not a public GitHub repo; `anthropics/skills` is the published catalog and is already in `sources.json`.
- **Issues #11–#12**: `hesreallyhim/awesome-claude-code`, `modelcontextprotocol/servers` (already in `sources.json`).
- **Issue #13**: `build_catalog` used nonexistent `governance.trust`; fixed to `trustworthiness`. Test import fix for `run_pipeline` dynamic load.

Closes #10, Closes #11, Closes #12, Closes #13

Made with [Cursor](https://cursor.com)